### PR TITLE
[fix] Typo in the query for existing impl

### DIFF
--- a/tech/_posts/2017-04-24-negative-chalk.md
+++ b/tech/_posts/2017-04-24-negative-chalk.md
@@ -753,7 +753,7 @@ hence that only the second impl of `Foo` could possibly apply?
 
 In the system proposed by this post, we'd follow a chain of events like the following:
 
-- The type checker asks: `exists<T> { compat { (): Make<T> } }`
+- The type checker asks: `exists<T> { compat { (): Bar<T> } }`
   - We check the first impl, and end up asking: `compat { (): Bar<?T> }`
     - We return `Maybe`, since we're within `compat` and there are indeed some
       compatible worlds for which `(): Bar<?T>` for some `?T`; but we have no


### PR DESCRIPTION
Very dense but great article. Thank you (even if I'm pretty sure I didn't understand everything 😛).

Also, there is a problem with nested list in the article. Looking in Github preview, I see this

![image](https://user-images.githubusercontent.com/2520723/79126377-1b087580-7da0-11ea-8ad1-9dbad6568387.png)

But on your blog, it renders like this

![image](https://user-images.githubusercontent.com/2520723/79126413-2a87be80-7da0-11ea-93e3-3c79f3c5351c.png)

I noticed at least to instances of this problem.